### PR TITLE
Fix Jolt benchmarks

### DIFF
--- a/jolt/algos/addition/src/main.rs
+++ b/jolt/algos/addition/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_add, verify_add) = guest::build_add();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_add(10, 20);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/division/src/main.rs
+++ b/jolt/algos/division/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_div, verify_div) = guest::build_div();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_div(40, 10);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/fib/src/main.rs
+++ b/jolt/algos/fib/src/main.rs
@@ -1,7 +1,7 @@
+use jolt::Serializable;
+use serde_json::Value;
 use std::fs::File;
 use std::io::BufReader;
-use serde_json::Value;
-use jolt::Serializable;
 
 pub fn main() {
     let file = File::open("../../inputs/data.json").expect("Failed to open input file");
@@ -18,12 +18,14 @@ pub fn main() {
     // println!("Prover Execution Time {:?}", prover_execution_trace_duration);
     println!();
 
-    let proving_time = std::time::Instant::now();
     let (prove_fib, verify_fib) = guest::build_fib();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_fib(n);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/for-loop/src/main.rs
+++ b/jolt/algos/for-loop/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_for_loop, verify_for_loop) = guest::build_for_loop();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_for_loop(10);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/merkle-leaf-proof/src/main.rs
+++ b/jolt/algos/merkle-leaf-proof/src/main.rs
@@ -2,13 +2,15 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove, verify) = guest::build_generate_merkle_proof();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove(5);
 
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/multiplication/src/main.rs
+++ b/jolt/algos/multiplication/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_mul, verify_mul) = guest::build_mul();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_mul(10, 20);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/poseidon/src/main.rs
+++ b/jolt/algos/poseidon/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove, verify) = guest::build_pos();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove();
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/sha256/src/main.rs
+++ b/jolt/algos/sha256/src/main.rs
@@ -2,14 +2,16 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_sha2, verify_sha2) = guest::build_sha2();
+    let proving_time = std::time::Instant::now();
 
     let input = &[5u8; 4000];
     let (output, proof) = prove_sha2(input);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 

--- a/jolt/algos/subtraction/src/main.rs
+++ b/jolt/algos/subtraction/src/main.rs
@@ -2,12 +2,14 @@ use jolt::Serializable;
 
 pub fn main() {
     let start = std::time::Instant::now();
-    let proving_time = std::time::Instant::now();
     let (prove_sub, verify_sub) = guest::build_sub();
+    let proving_time = std::time::Instant::now();
     let (output, proof) = prove_sub(100, 10);
     println!("Prover Time {:?}", proving_time.elapsed());
 
-    proof.save_to_file("proof.bin").expect("Failed to save proof to file");
+    proof
+        .save_to_file("proof.bin")
+        .expect("Failed to save proof to file");
     println!("Proof Size {:?}", proof.size().unwrap());
     println!();
 


### PR DESCRIPTION
`guest::build_*` computes the SRS and compiles the guest program, so it should not be included in prover time